### PR TITLE
swpの定義を元に戻す

### DIFF
--- a/ICBICSort.hs
+++ b/ICBICSort.hs
@@ -19,9 +19,9 @@ swapper (xs, y:ys) = swapper $? (zs++[w], ws)
         (w, ws) = swp (z:ys)
 
 swp :: Ord a => [a] -> (a, [a])
-swp xxs@(x:_) = case break (x<) xxs of
-  (xs, []) -> (x, tail xs)
-  (xs, ys) -> (z, tail xs++[x]++zs)
+swp (x:xs) = case break (x<) xs of
+  (xs, []) -> (x, xs)
+  (xs, ys) -> (z, xs++[x]++zs)
     where (z, zs) = swp ys
 
 sample = [1,3,2,5,4,7,6,0]


### PR DESCRIPTION
i == j のときのオリジナルは、a[i]とa[j]を比較しているので、前回swp の定義をそのように変更したつもりだったけれど、
これでは、i 以後の動作はオリジナルどおりだけど、i より前がオリジナルにはない余計な動作になる。

そもそも、ソーティングネットワークでコンパレータをどの要素間にどのような順でいれるかの話だというのであるから、
i == j の時の比較は意味がなく、スキップすべきだし、その方が swp の実装として単純に書ける。

一方、オリジナルでは、インデックスによる配列の操作を使っているので、
i == j をスキップするという実装は単純さを損うし、i == j において比較をしても
全体の意味に影響を与えないので、単純さを優先している。

というわけで swp の定義を前回の変更前に戻す提案です。